### PR TITLE
Implement rpi5 support - change to uci morse radio defaults

### DIFF
--- a/boards/bsp-common/files/uci-defaults/99_morse_radio_defaults
+++ b/boards/bsp-common/files/uci-defaults/99_morse_radio_defaults
@@ -44,9 +44,6 @@ fix_bcf_default() {
 		bcm2712,mm6108-spi)
 			bcf=bcf_fgh100mhaamd.bin
 		;;
-		bcm2712,mm8108-spi)
-			bcf=bcf_fgh100mhaamd.bin
-		;;
 		# This is the default build target for OpenMANET
 		morse,ekh01)
 			bcf=bcf_fgh100mhaamd.bin

--- a/boards/bsp-common/files/uci-defaults/99_morse_radio_defaults
+++ b/boards/bsp-common/files/uci-defaults/99_morse_radio_defaults
@@ -34,12 +34,17 @@ fix_bcf_default() {
 		;;
 		morse,mm6108-ekh01-sdio|\
 		bcm2711,mm6108-sdio|\
-		bcm2710,mm6108-sdio)
+		bcm2710,mm6108-sdio|\
+		bcm2712,mm6108-sdio)
 			bcf=bcf_mf04151.bin
         ;;
 		morse,mm6108-ekh01-spi|\
 		bcm2711,mm6108-spi|\
-		bcm2710,mm6108-spi)
+		bcm2710,mm6108-spi|\
+		bcm2712,mm6108-spi)
+			bcf=bcf_fgh100mhaamd.bin
+		;;
+		bcm2712,mm8108-spi)
 			bcf=bcf_fgh100mhaamd.bin
 		;;
 		# This is the default build target for OpenMANET


### PR DESCRIPTION
As requested here: https://github.com/OpenMANET/firmware/pull/14#pullrequestreview-3822494730

I believe https://github.com/OpenMANET/packages/blob/24.10/boards/bsp-bcm271x/files/board.d/03_openmanet_eth was already modified and has rpi5 support, I could be mistaken though