### PR TITLE
Add HaLow Link 2 board support

### DIFF
--- a/boards/bsp-common/files/uci-defaults/99_morse_radio_defaults
+++ b/boards/bsp-common/files/uci-defaults/99_morse_radio_defaults
@@ -26,8 +26,9 @@ fix_bcf_default() {
 		morse,ekh04v6)
 			bcf=bcf_ekh04_v6.bin
 		;;
-		morse,artini)
-			bcf=bcf_mm_hl1.bin
+		morse,halowlink2)
+			bcf=bcf_mm_hl2_ext.bin
+			channel=28
 		;;
 		morse,ekh01-01)
 			bcf=bcf_mf15457.bin
@@ -58,6 +59,7 @@ fix_bcf_default() {
 	[ -z "$bcf" ] && return 0
 
 	uci -q set wireless."${config}".bcf="${bcf}"
+	[ -n "$channel" ] && uci -q set wireless."${config}".channel="${channel}"
 
 }
 

--- a/boards/bsp-halowlink2/Makefile
+++ b/boards/bsp-halowlink2/Makefile
@@ -37,6 +37,9 @@ define Package/bsp-halowlink2/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
 	$(CP) ./files/uci-defaults/* $(1)/etc/uci-defaults/
 
+	$(INSTALL_DIR) $(1)/etc/board.d/
+	$(INSTALL_BIN) ./files/board.d/* $(1)/etc/board.d/
+
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/etc/init.d/* $(1)/etc/init.d/
 

--- a/boards/bsp-halowlink2/files/board.d/03_openmanet_eth
+++ b/boards/bsp-halowlink2/files/board.d/03_openmanet_eth
@@ -1,0 +1,17 @@
+#!/bin/sh
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board=$(board_name)
+
+board_config_update
+
+case "$board" in
+morse,halowlink2)
+	ucidef_set_interfaces_lan_wan "usblan lan" "wan"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/boards/bsp-halowlink2/files/uci-defaults/99_halowlink2_defaults
+++ b/boards/bsp-halowlink2/files/uci-defaults/99_halowlink2_defaults
@@ -1,0 +1,51 @@
+#!/bin/sh
+# HaLow Link 2 board defaults: channel 28 (916 MHz, 8 MHz BW), BCF, and LEDs
+
+. /lib/functions.sh
+
+set_halowlink2_defaults() {
+	local config="$1"
+	local type
+
+	config_get type "$config" type
+	[ "morse" = "$type" ] || return 0
+
+	uci -q set wireless."${config}".channel='28'
+	uci -q set wireless."${config}".bcf='bcf_mm_hl2_ext.bin'
+}
+
+board=$(board_name)
+[ "$board" = "morse,halowlink2" ] || exit 0
+
+config_load wireless
+config_foreach set_halowlink2_defaults wifi-device
+uci commit wireless
+
+# Configure RGB LED colors to match stock MorseMicro firmware
+# led0 = WiFi (green), led1 = Status (green heartbeat), led2 = HaLow (light purple)
+uci batch <<'EOF'
+set system.led_wifi=led
+set system.led_wifi.sysfs='rgb:led0'
+set system.led_wifi.trigger='netdev'
+set system.led_wifi.dev='phy1-ap0'
+set system.led_wifi.mode='tx rx'
+set system.led_wifi.color_red='0'
+set system.led_wifi.color_green='255'
+set system.led_wifi.color_blue='0'
+set system.led_status=led
+set system.led_status.sysfs='rgb:led1'
+set system.led_status.trigger='default-on'
+set system.led_status.default='1'
+set system.led_status.color_red='0'
+set system.led_status.color_green='255'
+set system.led_status.color_blue='0'
+set system.led_halow=led
+set system.led_halow.sysfs='rgb:led2'
+set system.led_halow.trigger='netdev'
+set system.led_halow.dev='wlan0'
+set system.led_halow.mode='link'
+set system.led_halow.color_red='255'
+set system.led_halow.color_green='0'
+set system.led_halow.color_blue='127'
+EOF
+uci commit system

--- a/lang/golang/golang-version.mk
+++ b/lang/golang/golang-version.mk
@@ -177,6 +177,8 @@ define Host/Install
 	$(call GoCompiler/$(HOST_GO_PROFILE_ID)/Install/Bin)
 	$(call GoCompiler/$(HOST_GO_PROFILE_ID)/Install/Src)
 	$(call GoCompiler/$(HOST_GO_PROFILE_ID)/Install/BinLinks)
+	$(LN) "go$(HOST_GO_VERSION_ID)" "$(HOST_GO_PREFIX)/bin/go"
+	$(LN) "gofmt$(HOST_GO_VERSION_ID)" "$(HOST_GO_PREFIX)/bin/gofmt"
 
 	rm -rf "$(HOST_GO_ROOT)/pkg/$(GO_HOST_OS_ARCH)"
 
@@ -188,6 +190,8 @@ endef
 
 define Host/Uninstall
 	rm -rf "$(HOST_GO_ROOT)/openwrt"
+	rm -f "$(HOST_GO_PREFIX)/bin/go"
+	rm -f "$(HOST_GO_PREFIX)/bin/gofmt"
 
 	$(call GoCompiler/$(HOST_GO_PROFILE_ID)/Uninstall/BinLinks)
 	$(call GoCompiler/$(HOST_GO_PROFILE_ID)/Uninstall)


### PR DESCRIPTION
- Add halowlink2 BCF and channel 28 defaults to bsp-common
- Add board-specific LED and wireless config
- Fix Go symlink issue in golang-version.mk