### PR TITLE
bsp-halowlink2: add board defaults and network config

### DIFF
--- a/boards/bsp-halowlink2/Makefile
+++ b/boards/bsp-halowlink2/Makefile
@@ -37,6 +37,9 @@ define Package/bsp-halowlink2/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
 	$(CP) ./files/uci-defaults/* $(1)/etc/uci-defaults/
 
+	$(INSTALL_DIR) $(1)/etc/board.d/
+	$(INSTALL_BIN) ./files/board.d/* $(1)/etc/board.d/
+
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/etc/init.d/* $(1)/etc/init.d/
 

--- a/boards/bsp-halowlink2/files/board.d/03_openmanet_eth
+++ b/boards/bsp-halowlink2/files/board.d/03_openmanet_eth
@@ -1,0 +1,17 @@
+#!/bin/sh
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board=$(board_name)
+
+board_config_update
+
+case "$board" in
+morse,halowlink2)
+	ucidef_set_interfaces_lan_wan "usblan lan" "wan"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/boards/bsp-halowlink2/files/uci-defaults/99_halowlink2_defaults
+++ b/boards/bsp-halowlink2/files/uci-defaults/99_halowlink2_defaults
@@ -1,0 +1,51 @@
+#!/bin/sh
+# HaLow Link 2 board defaults: channel 28 (916 MHz, 8 MHz BW), BCF, and LEDs
+
+. /lib/functions.sh
+
+set_halowlink2_defaults() {
+	local config="$1"
+	local type
+
+	config_get type "$config" type
+	[ "morse" = "$type" ] || return 0
+
+	uci -q set wireless."${config}".channel='28'
+	uci -q set wireless."${config}".bcf='bcf_mm_hl2_ext.bin'
+}
+
+board=$(board_name)
+[ "$board" = "morse,halowlink2" ] || exit 0
+
+config_load wireless
+config_foreach set_halowlink2_defaults wifi-device
+uci commit wireless
+
+# Configure RGB LED colors to match stock MorseMicro firmware
+# led0 = WiFi (green), led1 = Status (green heartbeat), led2 = HaLow (light purple)
+uci batch <<'EOF'
+set system.led_wifi=led
+set system.led_wifi.sysfs='rgb:led0'
+set system.led_wifi.trigger='netdev'
+set system.led_wifi.dev='phy1-ap0'
+set system.led_wifi.mode='tx rx'
+set system.led_wifi.color_red='0'
+set system.led_wifi.color_green='255'
+set system.led_wifi.color_blue='0'
+set system.led_status=led
+set system.led_status.sysfs='rgb:led1'
+set system.led_status.trigger='default-on'
+set system.led_status.default='1'
+set system.led_status.color_red='0'
+set system.led_status.color_green='255'
+set system.led_status.color_blue='0'
+set system.led_halow=led
+set system.led_halow.sysfs='rgb:led2'
+set system.led_halow.trigger='netdev'
+set system.led_halow.dev='wlan0'
+set system.led_halow.mode='link'
+set system.led_halow.color_red='255'
+set system.led_halow.color_green='0'
+set system.led_halow.color_blue='127'
+EOF
+uci commit system


### PR DESCRIPTION
Add missing BSP files for HaLow Link 2:
- uci-defaults/99_halowlink2_defaults: wireless channel 28, BCF, RGB LED config
- board.d/03_openmanet_eth: network interfaces (usblan+lan as LAN, wan as WAN)
- Updated Makefile to install board.d scripts