### PR TITLE
Fix adsb to cot issues

### DIFF
--- a/utils/adsbtocot/Makefile
+++ b/utils/adsbtocot/Makefile
@@ -15,7 +15,7 @@ define Package/adsbtocot
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=ADS-B to Cursor-on-Target (ADSBCOT) for OpenWrt (dump1090 local)
-  DEPENDS:=+python3 +dump1090 +rtl-sdr
+  DEPENDS:=+python3 +python3-cryptography +dump1090 +rtl-sdr
 endef
 
 define Package/adsbtocot/description


### PR DESCRIPTION
Add python3 crypto library that is needed for the adsb to cot script.