### PR TITLE
chore: update openmanetd

### DIFF
--- a/openmanetd/Makefile
+++ b/openmanetd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openmanetd
-PKG_VERSION:=1.2.27
+PKG_VERSION:=1.2.28
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
Update openmanetd to [1.2.28](https://github.com/OpenMANET/openmanetd/releases/tag/1.2.28)