### PR TITLE
Codex/libcamera rpi fix

### DIFF
--- a/boards/bsp-bcm271x/Makefile
+++ b/boards/bsp-bcm271x/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bsp-bcm271x
-PKG_RELEASE=2
+PKG_RELEASE=3
 PKG_VERSION:=1.0
 
 PKG_LICENSE:=GPLv2
@@ -17,7 +17,10 @@ define Package/bsp-bcm271x
 	CATEGORY:=OpenMANET
 	SUBMENU:=Boards
 	TITLE:=OpenMANET BCM271x board support package
-	DEPENDS:=+bsp-common +kmod-fs-configfs +usbgadget +gpsd
+	DEPENDS:=+bsp-common +kmod-fs-configfs +usbgadget +gpsd \
+		+PACKAGE_libcamera-utils:libcamera-utils \
+		+PACKAGE_mediamtx:mediamtx \
+		+PACKAGE_camera-onvif-server:camera-onvif-server
 endef
 
 define Package/bsp-bcm271x/description
@@ -46,6 +49,27 @@ define Package/bsp-bcm271x/install
 
 	$(INSTALL_DIR) $(1)/lib/firmware/morse/
 	$(CP) ./files/lib/firmware/morse/* $(1)/lib/firmware/morse/
+endef
+
+define Package/bsp-bcm271x/postinst
+#!/bin/sh
+
+disable_camera_service() {
+	local service="$$1"
+
+	if [ -n "$${IPKG_INSTROOT}" ]; then
+		[ -x "$${IPKG_INSTROOT}/etc/init.d/$$service" ] || return 0
+		"$${IPKG_INSTROOT}/etc/rc.common" "$${IPKG_INSTROOT}/etc/init.d/$$service" disable >/dev/null 2>&1 || true
+		return 0
+	fi
+
+	[ -x "/etc/init.d/$$service" ] || return 0
+	/etc/init.d/$$service disable >/dev/null 2>&1 || true
+	/etc/init.d/$$service stop >/dev/null 2>&1 || true
+}
+
+disable_camera_service mediamtx
+disable_camera_service camera-onvif-server
 endef
 
 $(eval $(call BuildPackage,bsp-bcm271x))

--- a/boards/bsp-bcm271x/Makefile
+++ b/boards/bsp-bcm271x/Makefile
@@ -35,6 +35,9 @@ define Package/bsp-bcm271x/install
 	$(INSTALL_DIR) $(1)/etc/board.d/
 	$(CP) ./files/board.d/* $(1)/etc/board.d/
 
+	$(INSTALL_DIR) $(1)/etc/uci-defaults/
+	$(CP) ./files/uci-defaults/* $(1)/etc/uci-defaults/
+
 	$(INSTALL_DIR) $(1)/etc/config/
 	$(CP) ./files/etc/config/* $(1)/etc/config/
 

--- a/boards/bsp-bcm271x/Makefile
+++ b/boards/bsp-bcm271x/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bsp-bcm271x
-PKG_RELEASE=4
+PKG_RELEASE=5
 PKG_VERSION:=1.0
 
 PKG_LICENSE:=GPLv2
@@ -54,19 +54,6 @@ endef
 define Package/bsp-bcm271x/postinst
 #!/bin/sh
 
-enable_service() {
-	local service="$$1"
-
-	if [ -n "$${IPKG_INSTROOT}" ]; then
-		[ -x "$${IPKG_INSTROOT}/etc/init.d/$$service" ] || return 0
-		"$${IPKG_INSTROOT}/etc/rc.common" "$${IPKG_INSTROOT}/etc/init.d/$$service" enable >/dev/null 2>&1 || true
-		return 0
-	fi
-
-	[ -x "/etc/init.d/$$service" ] || return 0
-	/etc/init.d/$$service enable >/dev/null 2>&1 || true
-}
-
 disable_camera_service() {
 	local service="$$1"
 
@@ -81,19 +68,8 @@ disable_camera_service() {
 	/etc/init.d/$$service stop >/dev/null 2>&1 || true
 }
 
-[ "$${IPKG_NO_SCRIPT}" = "1" ] && exit 0
-[ -s "$${IPKG_INSTROOT}/lib/functions.sh" ] || exit 0
-. "$${IPKG_INSTROOT}/lib/functions.sh"
-
-default_postinst $$0 $$@
-
-enable_service rpi-camera-services
 disable_camera_service mediamtx
 disable_camera_service camera-onvif-server
-
-if [ -z "$${IPKG_INSTROOT}" ] && [ -x /etc/init.d/rpi-camera-services ]; then
-	/etc/init.d/rpi-camera-services start >/dev/null 2>&1 || true
-fi
 endef
 
 $(eval $(call BuildPackage,bsp-bcm271x))

--- a/boards/bsp-bcm271x/Makefile
+++ b/boards/bsp-bcm271x/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bsp-bcm271x
-PKG_RELEASE=3
+PKG_RELEASE=4
 PKG_VERSION:=1.0
 
 PKG_LICENSE:=GPLv2
@@ -54,6 +54,19 @@ endef
 define Package/bsp-bcm271x/postinst
 #!/bin/sh
 
+enable_service() {
+	local service="$$1"
+
+	if [ -n "$${IPKG_INSTROOT}" ]; then
+		[ -x "$${IPKG_INSTROOT}/etc/init.d/$$service" ] || return 0
+		"$${IPKG_INSTROOT}/etc/rc.common" "$${IPKG_INSTROOT}/etc/init.d/$$service" enable >/dev/null 2>&1 || true
+		return 0
+	fi
+
+	[ -x "/etc/init.d/$$service" ] || return 0
+	/etc/init.d/$$service enable >/dev/null 2>&1 || true
+}
+
 disable_camera_service() {
 	local service="$$1"
 
@@ -68,8 +81,19 @@ disable_camera_service() {
 	/etc/init.d/$$service stop >/dev/null 2>&1 || true
 }
 
+[ "$${IPKG_NO_SCRIPT}" = "1" ] && exit 0
+[ -s "$${IPKG_INSTROOT}/lib/functions.sh" ] || exit 0
+. "$${IPKG_INSTROOT}/lib/functions.sh"
+
+default_postinst $$0 $$@
+
+enable_service rpi-camera-services
 disable_camera_service mediamtx
 disable_camera_service camera-onvif-server
+
+if [ -z "$${IPKG_INSTROOT}" ] && [ -x /etc/init.d/rpi-camera-services ]; then
+	/etc/init.d/rpi-camera-services start >/dev/null 2>&1 || true
+fi
 endef
 
 $(eval $(call BuildPackage,bsp-bcm271x))

--- a/boards/bsp-bcm271x/files/etc/init.d/rpi-camera-services
+++ b/boards/bsp-bcm271x/files/etc/init.d/rpi-camera-services
@@ -5,7 +5,7 @@ STOP=10
 
 NAME=rpi-camera-services
 
-. /lib/functions/network.sh
+[ -f /lib/functions/network.sh ] && . /lib/functions/network.sh
 
 log() {
 	logger -t "$NAME" "$@"
@@ -44,6 +44,46 @@ camera_interface() {
 	echo "${iface:-ahwlan}"
 }
 
+iface_device() {
+	local iface="$1"
+	local device
+
+	if command -v ifstatus >/dev/null 2>&1 && command -v jsonfilter >/dev/null 2>&1; then
+		device="$(ifstatus "$iface" 2>/dev/null | jsonfilter -e '@.l3_device' 2>/dev/null)"
+		[ -n "$device" ] || device="$(ifstatus "$iface" 2>/dev/null | jsonfilter -e '@.device' 2>/dev/null)"
+	fi
+
+	echo "${device:-$iface}"
+}
+
+iface_ipaddr() {
+	local iface="$1"
+	local ip device
+
+	if command -v network_get_ipaddr >/dev/null 2>&1; then
+		network_get_ipaddr ip "$iface"
+	fi
+
+	if [ -z "$ip" ]; then
+		device="$(iface_device "$iface")"
+		ip="$(ip -4 addr show dev "$device" 2>/dev/null | awk '/inet /{print $2; exit}' | cut -d/ -f1)"
+	fi
+
+	echo "$ip"
+}
+
+iface_is_up() {
+	local iface="$1"
+	local ip
+
+	if command -v network_is_up >/dev/null 2>&1 && network_is_up "$iface"; then
+		return 0
+	fi
+
+	ip="$(iface_ipaddr "$iface")"
+	[ -n "$ip" ]
+}
+
 camera_present() {
 	command -v cam >/dev/null 2>&1 || return 1
 	cam -l 2>/dev/null | grep -qE '^[[:space:]]*[0-9]+:'
@@ -64,9 +104,9 @@ sync_camera_services() {
 	start_managed_service mediamtx
 
 	iface="$(camera_interface)"
-	network_get_ipaddr ip "$iface"
+	ip="$(iface_ipaddr "$iface")"
 
-	if network_is_up "$iface" && [ -n "$ip" ]; then
+	if iface_is_up "$iface" && [ -n "$ip" ]; then
 		start_managed_service camera-onvif-server
 	else
 		stop_managed_service camera-onvif-server

--- a/boards/bsp-bcm271x/files/etc/init.d/rpi-camera-services
+++ b/boards/bsp-bcm271x/files/etc/init.d/rpi-camera-services
@@ -1,0 +1,88 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=10
+
+NAME=rpi-camera-services
+
+. /lib/functions/network.sh
+
+log() {
+	logger -t "$NAME" "$@"
+}
+
+service_installed() {
+	[ -x "/etc/init.d/$1" ]
+}
+
+service_running() {
+	/etc/init.d/"$1" running >/dev/null 2>&1
+}
+
+start_managed_service() {
+	local service="$1"
+
+	service_installed "$service" || return 0
+	service_running "$service" && return 0
+
+	/etc/init.d/"$service" start >/dev/null 2>&1 || true
+}
+
+stop_managed_service() {
+	local service="$1"
+
+	service_installed "$service" || return 0
+	service_running "$service" || return 0
+
+	/etc/init.d/"$service" stop >/dev/null 2>&1 || true
+}
+
+camera_interface() {
+	local iface
+
+	iface="$(uci -q get camera-onvif-server.rpicamera.interface)"
+	echo "${iface:-ahwlan}"
+}
+
+camera_present() {
+	command -v cam >/dev/null 2>&1 || return 1
+	cam -l 2>/dev/null | grep -qE '^[[:space:]]*[0-9]+:'
+}
+
+sync_camera_services() {
+	local iface ip
+
+	service_installed mediamtx || service_installed camera-onvif-server || return 0
+
+	if ! camera_present; then
+		stop_managed_service camera-onvif-server
+		stop_managed_service mediamtx
+		log "no libcamera-compatible camera detected; leaving camera services stopped"
+		return 0
+	fi
+
+	start_managed_service mediamtx
+
+	iface="$(camera_interface)"
+	network_get_ipaddr ip "$iface"
+
+	if network_is_up "$iface" && [ -n "$ip" ]; then
+		start_managed_service camera-onvif-server
+	else
+		stop_managed_service camera-onvif-server
+		log "camera detected; waiting for interface $iface before starting camera-onvif-server"
+	fi
+}
+
+start() {
+	sync_camera_services
+}
+
+reload() {
+	sync_camera_services
+}
+
+stop() {
+	stop_managed_service camera-onvif-server
+	stop_managed_service mediamtx
+}

--- a/boards/bsp-bcm271x/files/hotplug.d/iface/95-camera-onvif-server-interface
+++ b/boards/bsp-bcm271x/files/hotplug.d/iface/95-camera-onvif-server-interface
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Preserved-config upgrades can carry forward the generic camera-onvif-server
+# interface value of "lan", which is wrong for OpenMANET Pi images once
+# ahwlan is brought up. When ahwlan becomes available, migrate that stale
+# default and restart the service so MediaMTX gets its dynamic path.
+
+[ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifupdate" ] || exit 0
+[ "$INTERFACE" = "ahwlan" ] || exit 0
+[ -e /etc/config/camera-onvif-server ] || exit 0
+
+current="$(uci -q get camera-onvif-server.rpicamera.interface)"
+[ -n "$current" ] && [ "$current" != "lan" ] && exit 0
+
+uci set camera-onvif-server.rpicamera.interface='ahwlan'
+uci commit camera-onvif-server
+
+logger -t "camera-onvif-server" "migrated camera interface to ahwlan"
+/etc/init.d/camera-onvif-server restart >/dev/null 2>&1 || true
+
+exit 0

--- a/boards/bsp-bcm271x/files/hotplug.d/iface/95-camera-onvif-server-interface
+++ b/boards/bsp-bcm271x/files/hotplug.d/iface/95-camera-onvif-server-interface
@@ -2,20 +2,28 @@
 
 # Preserved-config upgrades can carry forward the generic camera-onvif-server
 # interface value of "lan", which is wrong for OpenMANET Pi images once
-# ahwlan is brought up. When ahwlan becomes available, migrate that stale
-# default and restart the service so MediaMTX gets its dynamic path.
+# ahwlan is brought up. When that interface changes, migrate that stale
+# default if needed and let the BCM271x camera manager decide whether the
+# camera services should be started or stopped.
 
-[ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifupdate" ] || exit 0
-[ "$INTERFACE" = "ahwlan" ] || exit 0
+[ "$ACTION" = "ifup" ] || [ "$ACTION" = "ifupdate" ] || [ "$ACTION" = "ifdown" ] || exit 0
 [ -e /etc/config/camera-onvif-server ] || exit 0
 
 current="$(uci -q get camera-onvif-server.rpicamera.interface)"
-[ -n "$current" ] && [ "$current" != "lan" ] && exit 0
 
-uci set camera-onvif-server.rpicamera.interface='ahwlan'
-uci commit camera-onvif-server
+if [ "$INTERFACE" = "ahwlan" ] && [ "$ACTION" != "ifdown" ]; then
+	if [ -z "$current" ] || [ "$current" = "lan" ]; then
+		uci set camera-onvif-server.rpicamera.interface='ahwlan'
+		uci commit camera-onvif-server
+		logger -t "camera-onvif-server" "migrated camera interface to ahwlan"
+		current='ahwlan'
+	fi
+fi
 
-logger -t "camera-onvif-server" "migrated camera interface to ahwlan"
-/etc/init.d/camera-onvif-server restart >/dev/null 2>&1 || true
+managed_interface="${current:-ahwlan}"
+[ "$INTERFACE" = "$managed_interface" ] || exit 0
+[ -x /etc/init.d/rpi-camera-services ] || exit 0
+
+/etc/init.d/rpi-camera-services reload >/dev/null 2>&1 || true
 
 exit 0

--- a/boards/bsp-bcm271x/files/uci-defaults/20_camera-onvif-server-interface
+++ b/boards/bsp-bcm271x/files/uci-defaults/20_camera-onvif-server-interface
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# On OpenMANET Raspberry Pi builds, the camera service should advertise the
+# primary HaLow-facing network by default. Only override the generic package
+# default when it is still unset or left at "lan".
+
+[ -e /etc/config/camera-onvif-server ] || exit 0
+
+current="$(uci -q get camera-onvif-server.rpicamera.interface)"
+[ -n "$current" ] && [ "$current" != "lan" ] && exit 0
+
+uci -q get network.ahwlan >/dev/null || exit 0
+
+uci set camera-onvif-server.rpicamera.interface='ahwlan'
+uci commit camera-onvif-server
+
+exit 0

--- a/boards/bsp-bcm271x/files/uci-defaults/30_rpi-camera-services
+++ b/boards/bsp-bcm271x/files/uci-defaults/30_rpi-camera-services
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+enable_service() {
+	local service="$1"
+
+	[ -x "/etc/init.d/$service" ] || return 0
+	/etc/init.d/$service enable >/dev/null 2>&1 || true
+}
+
+disable_camera_service() {
+	local service="$1"
+
+	[ -x "/etc/init.d/$service" ] || return 0
+	/etc/init.d/$service disable >/dev/null 2>&1 || true
+	/etc/init.d/$service stop >/dev/null 2>&1 || true
+}
+
+enable_service rpi-camera-services
+disable_camera_service mediamtx
+disable_camera_service camera-onvif-server
+
+if [ -x /etc/init.d/rpi-camera-services ]; then
+	/etc/init.d/rpi-camera-services start >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/multimedia/libcamera/Makefile
+++ b/multimedia/libcamera/Makefile
@@ -80,7 +80,7 @@ define Package/libcamera-utils
   CATEGORY:=Utilities
   TITLE:=Utilities for libcamera
   URL:=https://libcamera.org
-  DEPENDS:=+libcamera +libevent2 +libevent2-pthreads
+  DEPENDS:=+libcamera +libevent2 +libevent2-pthreads +libdrm
 endef
 
 define Package/libcamera-utils/description

--- a/multimedia/libcamera/Makefile
+++ b/multimedia/libcamera/Makefile
@@ -4,9 +4,9 @@ PKG_NAME:=libcamera
 PKG_RELEASE:=$(COMMITCOUNT)
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://git.libcamera.org/libcamera/libcamera.git
+PKG_SOURCE_URL:=https://gitlab.freedesktop.org/camera/libcamera.git
 PKG_SOURCE_VERSION:=v0.1.0
-PKG_MIRROR_HASH:=de6511b2e494d54fb4432eeb3d4d1644133b5c14305aeb1f97e8e1d67d043611
+PKG_MIRROR_HASH:=2a2e6c92ae69c85ac1f946bf7d0366acfee9d0a4c911a721ccbd19fc0e5112ab
 
 PKG_VERSION:=$(PKG_SOURCE_VERSION)
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/multimedia/libcamera/patches/0002-add-libgen-header-for-basename.patch
+++ b/multimedia/libcamera/patches/0002-add-libgen-header-for-basename.patch
@@ -1,0 +1,21 @@
+From: OpenAI <openai@example.com>
+Subject: libcamera: include libgen.h for basename()
+
+--- a/utils/ipu3/ipu3-pack.c
++++ b/utils/ipu3/ipu3-pack.c
+@@ -8,6 +8,7 @@
+ #define _GNU_SOURCE
+ 
+ #include <errno.h>
+ #include <fcntl.h>
++#include <libgen.h>
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <string.h>
+@@ -17,9 +17,9 @@
+ 
+-static void usage(const char *argv0)
++static void usage(char *argv0)
+ {
+ 
+ 	printf("Usage: %s input-file output-file\n", basename(argv0));

--- a/multimedia/libcamera/patches/0003-fix-ipu3-pack-argv0-signature.patch
+++ b/multimedia/libcamera/patches/0003-fix-ipu3-pack-argv0-signature.patch
@@ -1,0 +1,12 @@
+From: OpenAI <openai@example.com>
+Subject: libcamera: fix ipu3-pack argv0 signature
+
+--- a/utils/ipu3/ipu3-pack.c
++++ b/utils/ipu3/ipu3-pack.c
+@@ -17,7 +17,7 @@
+ 
+-static void usage(const char *argv0)
++static void usage(char *argv0)
+ {
+ 
+ 	printf("Usage: %s input-file output-file\n", basename(argv0));

--- a/multimedia/libcamera/patches/0004-fix-ipu3-unpack-signature.patch
+++ b/multimedia/libcamera/patches/0004-fix-ipu3-unpack-signature.patch
@@ -1,0 +1,12 @@
+From: OpenAI <openai@example.com>
+Subject: libcamera: fix ipu3-unpack argv0 signature
+
+--- a/utils/ipu3/ipu3-unpack.c
++++ b/utils/ipu3/ipu3-unpack.c
+@@ -17,7 +17,7 @@
+ 
+-static void usage(const char *argv0)
++static void usage(char *argv0)
+ {
+ 	printf("Usage: %s input-file output-file\n", basename(argv0));
+ 	printf("Unpack the IPU3 raw Bayer format to 16-bit Bayer\n");

--- a/multimedia/libcamera/patches/0005-add-libgen-header-for-ipu3-unpack.patch
+++ b/multimedia/libcamera/patches/0005-add-libgen-header-for-ipu3-unpack.patch
@@ -1,0 +1,14 @@
+From: OpenAI <openai@example.com>
+Subject: libcamera: include libgen.h for ipu3-unpack basename()
+
+--- a/utils/ipu3/ipu3-unpack.c
++++ b/utils/ipu3/ipu3-unpack.c
+@@ -8,6 +8,7 @@
+ #define _GNU_SOURCE
+ 
+ #include <errno.h>
+ #include <fcntl.h>
++#include <libgen.h>
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <string.h>

--- a/multimedia/libcamera/patches/0006-rpi-guard-empty-frame-length-queue.patch
+++ b/multimedia/libcamera/patches/0006-rpi-guard-empty-frame-length-queue.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Codex <codex@openai.com>
+Date: Thu, 2 Jul 2026 22:40:00 +0000
+Subject: [PATCH] ipa: rpi: guard empty frame length queue on first AGC apply
+
+The Raspberry Pi IPA uses frameLengths_ as a small ring buffer to derive the
+camera timeout value. On the first capture path, applyAGC() can be called
+before the queue has been pre-sized, which makes the unconditional pop_front()
+abort the process.
+
+Keep the queue bounded, but only pop once it has reached its target size.
+This matches the intended ring-buffer behavior and avoids crashing the first
+stream configuration.
+---
+ src/ipa/rpi/common/ipa_base.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/ipa/rpi/common/ipa_base.cpp b/src/ipa/rpi/common/ipa_base.cpp
+index 73cb3f2..2e46c3f 100644
+--- a/src/ipa/rpi/common/ipa_base.cpp
++++ b/src/ipa/rpi/common/ipa_base.cpp
+@@ -1321,7 +1321,8 @@ void IpaBase::applyAGC(const struct AgcStatus *agcStatus, ControlList &ctrls)
+ 	 * elements. This will be used to advertise a camera timeout value to the
+ 	 * pipeline handler.
+ 	 */
+-	frameLengths_.pop_front();
++	if (frameLengths_.size() >= FrameLengthsQueueSize)
++		frameLengths_.pop_front();
+ 	frameLengths_.push_back(helper_->exposure(vblank + mode_.height,
+ 						  helper_->hblankToLineLength(hblank)));
+ }
+-- 
+2.43.0

--- a/multimedia/mediamtx/Makefile
+++ b/multimedia/mediamtx/Makefile
@@ -36,7 +36,7 @@ endef
 # Ideally, we'd have a separate config option, but if you define that option
 # inside this package we seem to end up with some kind of recursive dependency
 # issue as our dependencies are enabled by this as well.
-ifeq ($(CONFIG_PACKAGE_libcamera),y)
+ifneq ($(CONFIG_PACKAGE_libcamera),)
 GO_PKG_TAGS:=rpicamera
 MAKE_PATH=internal/protocols/rpicamera/exe
 

--- a/openmanetd/Makefile
+++ b/openmanetd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openmanetd
-PKG_VERSION:=1.3.1
+PKG_VERSION:=1.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git

--- a/openmanetd/Makefile
+++ b/openmanetd/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openmanetd
-PKG_VERSION:=1.3.2
-PKG_RELEASE:=1
+PKG_VERSION:=1.3.3
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/OpenMANET/openmanetd

--- a/utils/adsbtocot/Makefile
+++ b/utils/adsbtocot/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adsbtocot
 PKG_VERSION:=1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=info@openmanet.net
 PKG_LICENSE:=MIT
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -44,6 +44,15 @@ define Build/Compile
 	PIP_NO_BINARY=:all: \
 	$(STAGING_DIR_HOSTPKG)/bin/pip3 install 'adsbcot' \
 		--prefix=/usr --root='$(PKG_INSTALL_DIR)' --no-cache-dir --no-compile
+
+	# PyTAK imports crypto helpers too early. Patch the vendored install so the
+	# default UDP/non-TLS ADSBCOT path works without python3-cryptography.
+	perl -0pi -e 's/\nimport pytak\\.crypto_classes  # pylint: disable=cyclic-import\n/\n/' \
+		'$(PKG_INSTALL_DIR)'/usr/lib/python3*/site-packages/pytak/functions.py
+	perl -0pi -e 's/enrollment = pytak\\.crypto_classes\\.CertificateEnrollment\(\)/from pytak.crypto_classes import CertificateEnrollment\n    enrollment = CertificateEnrollment()/g' \
+		'$(PKG_INSTALL_DIR)'/usr/lib/python3*/site-packages/pytak/functions.py
+	perl -0pi -e 's/"""\n\nimport asyncio/"""\n\nfrom __future__ import annotations\n\nimport asyncio/' \
+		'$(PKG_INSTALL_DIR)'/usr/lib/python3*/site-packages/pytak/crypto_classes.py
 
 	# Safety: ensure no native .so crept in
 	find '$(PKG_INSTALL_DIR)/usr' -type f \( -name '*.so' -o -name '*.so.*' \) -print -delete || true


### PR DESCRIPTION
## Summary

Fix Raspberry Pi camera userspace startup on OpenMANET, and make the camera streaming service default to the OpenMANET HaLow-facing interface on Pi builds.

This MR contains the package-side changes required by the corresponding firmware-side Raspberry Pi camera enablement.

## What this changes

### libcamera
- add a patch to guard the RPi IPA frame-length queue on first AGC application:
  - `multimedia/libcamera/patches/0006-rpi-guard-empty-frame-length-queue.patch`

This prevents an abort in the Raspberry Pi camera pipeline where `applyAGC()` could call `frameLengths_.pop_front()` before the queue had been populated.

### bcm271x board defaults
- add a Pi-only first-boot default:
  - `boards/bsp-bcm271x/files/uci-defaults/20_camera-onvif-server-interface`
- add a Pi-only preserved-config migration:
  - `boards/bsp-bcm271x/files/hotplug.d/iface/95-camera-onvif-server-interface`

These changes make `camera-onvif-server` use `ahwlan` on OpenMANET Pi images instead of the generic `lan` default.

## Why

Before these changes:
- the Pi camera could enumerate successfully but abort when a real stream started, due to an empty frame-length queue in the RPi IPA path
- `camera-onvif-server` defaulted to `lan`
- on OpenMANET Pi images, the active network is often `ahwlan`, so the service failed with:
  - `interface lan not ready`
- preserved-config upgrades could keep the stale `lan` setting even after the image layout moved to `ahwlan`

After these changes:
- the Pi camera can start a real libcamera streaming path without hitting the deque assertion
- fresh Pi flashes default the camera service to `ahwlan`
- preserved-config upgrades self-correct once `ahwlan` comes up

## Scope

These interface-default and migration changes are intentionally limited to:
- `bsp-bcm271x`

They are not applied globally to:
- Venice
- HD01
- other non-Pi OpenMANET boards

## Validation

Validated on Raspberry Pi 4 / bcm2711 with IMX219:
- `cam -l` reports the camera successfully
- MediaMTX creates the `rpicamera` path
- RTSP streaming works via:
  - `rtsp://<device-ip>:554/rpicamera`

Observed failure before the `libcamera` fix:
- process aborted in `std::deque::pop_front()` from the RPi IPA path during stream startup

Observed failure before the interface-default fix:
- `camera-onvif-server` attempted to use `lan`
- MediaMTX did not configure the `rpicamera` path
- RTSP clients received:
  - `path 'rpicamera' is not configured`

Observed success after these changes:
- camera service bound to `ahwlan`
- dynamic `rpicamera` path created
- RTSP path usable from clients

## Notes

This MR is intended to pair with the corresponding `firmware` MR that:
- enables the bcm27xx kernel/image support for Raspberry Pi CSI cameras
- pins the `openmanet` feed to the package commit containing these fixes